### PR TITLE
wrap server logs in a pre

### DIFF
--- a/views/controller/servers/logs.dt
+++ b/views/controller/servers/logs.dt
@@ -1,2 +1,3 @@
-- foreach (line; logs)
-    p= line
+pre
+    - foreach (line; logs)
+        |= line ~ "\n"


### PR DESCRIPTION
monospace makes it much easier to read